### PR TITLE
Fix ExecIds type in container inspect in swagger file

### DIFF
--- a/docker-swagger.yaml
+++ b/docker-swagger.yaml
@@ -4640,7 +4640,7 @@ paths:
               AppArmorProfile:
                 type: "string"
               ExecIDs:
-                type: "string"
+                type: "array"
               HostConfig:
                 $ref: "#/definitions/HostConfig"
               GraphDriver:


### PR DESCRIPTION
Fixes https://github.com/docker-php/docker-php/issues/304 where ExecIds expects a string but gets an array